### PR TITLE
Performance improvements

### DIFF
--- a/bench/github_test.go
+++ b/bench/github_test.go
@@ -333,7 +333,7 @@ func loadCloudReticRouter(routes []route) http.Handler {
 	return rt
 }
 
-// 1,429,306 ns/op, 58,635 B/op, 406 allocs/op
+// 796,411 ns/op, 58,635 B/op, 406 allocs/op
 func BenchmarkCloudReticRouter_GithubAll(b *testing.B) {
 	rt := loadCloudReticRouter(githubAPI)
 	benchRoutes(b, rt, githubAPI)

--- a/bench/github_test.go
+++ b/bench/github_test.go
@@ -327,7 +327,7 @@ func loadCloudReticRouter(routes []route) http.Handler {
 
 	rt, _ := router.New()
 	for _, rout := range routes {
-		r, _ := crroute.New(rout.Path, crroute.WithMethods(rout.Method))
+		r, _ := crroute.New(rout.Method, rout.Path)
 		rt.AddRoute(r, h)
 	}
 	return rt

--- a/bench/github_test.go
+++ b/bench/github_test.go
@@ -333,7 +333,7 @@ func loadCloudReticRouter(routes []route) http.Handler {
 	return rt
 }
 
-// 796,411 ns/op, 58,635 B/op, 406 allocs/op
+// 296,177 ns/op, 58,635 B/op, 406 allocs/op
 func BenchmarkCloudReticRouter_GithubAll(b *testing.B) {
 	rt := loadCloudReticRouter(githubAPI)
 	benchRoutes(b, rt, githubAPI)

--- a/pkg/route/bench_route_test.go
+++ b/pkg/route/bench_route_test.go
@@ -14,7 +14,7 @@ func use(any) {}
 //
 // 185 ns/op, 256 B/op, 1 allocs/op
 func BenchmarkStringRoute(b *testing.B) {
-	rt := Declare("/a/b/c/d/e/f/g/h")
+	rt := Declare(http.MethodGet, "/a/b/c/d/e/f/g/h")
 	req, _ := http.NewRequest(http.MethodGet, "http://url.com/a/b/c/d/e/f/g/h", nil)
 	var out *http.Request
 	for i := 0; i < b.N; i++ {
@@ -27,7 +27,7 @@ func BenchmarkStringRoute(b *testing.B) {
 //
 // 396 ns/op, 256 B/op, 1 allocs/op
 func BenchmarkWildcardRoute(b *testing.B) {
-	rt := Declare("/[a]/[b]/[c]/[d]/[e]/[f]/[g]/[h]")
+	rt := Declare(http.MethodGet, "/[a]/[b]/[c]/[d]/[e]/[f]/[g]/[h]")
 	req, _ := http.NewRequest(http.MethodGet, "http://url.com/a/b/c/d/e/f/g/h", nil)
 	var out *http.Request
 	for i := 0; i < b.N; i++ {
@@ -40,7 +40,7 @@ func BenchmarkWildcardRoute(b *testing.B) {
 //
 // 469 ns/op, 257 B/op, 1 allocs/op
 func BenchmarkRegexRoute(b *testing.B) {
-	rt := Declare("/{.+}/{.+}/{.+}/{.+}/{.+}/{.+}/{.+}/{.+}")
+	rt := Declare(http.MethodGet, "/{.+}/{.+}/{.+}/{.+}/{.+}/{.+}/{.+}/{.+}")
 	req, _ := http.NewRequest(http.MethodGet, "http://url.com/a/b/c/d/e/f/g/h", nil)
 	var out *http.Request
 	for i := 0; i < b.N; i++ {
@@ -53,7 +53,7 @@ func BenchmarkRegexRoute(b *testing.B) {
 //
 // 520 ns/op, 257 B/op, 1 allocs/op
 func BenchmarkPartialRoute(b *testing.B) {
-	rt := Declare("/+")
+	rt := Declare(http.MethodGet, "/+")
 	req, _ := http.NewRequest(http.MethodGet, "http://url.com/a/b/c/d/e/f/g/h", nil)
 	var out *http.Request
 	for i := 0; i < b.N; i++ {

--- a/pkg/route/config.go
+++ b/pkg/route/config.go
@@ -1,23 +1,4 @@
 package route
 
-import (
-	"net/http"
-
-	"github.com/cloudretic/go-collections/pkg/slices"
-)
-
 // RouteConfigFuncs can be applied to a Route at creation.
 type ConfigFunc func(Route) error
-
-// Filter out requests that don't have a method included in methods
-func WithMethods(methods ...string) ConfigFunc {
-	return func(r Route) error {
-		r.Attach(func(r *http.Request) *http.Request {
-			if !slices.Contains(methods, r.Method) {
-				return nil
-			}
-			return r
-		})
-		return nil
-	}
-}

--- a/pkg/route/default.go
+++ b/pkg/route/default.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/cloudretic/router/pkg/middleware"
 	"github.com/cloudretic/router/pkg/path"
 )
 
@@ -40,6 +39,10 @@ func (part *stringPart) Eq(other Part) bool {
 	return false
 }
 
+func (part *stringPart) Expr() string {
+	return part.val
+}
+
 // WILDCARDS
 
 // Wildcard route Parts store parameters for use by the router in handlers.
@@ -57,7 +60,7 @@ func build_wildcardPart(param string) (*wildcardPart, error) {
 
 func (part *wildcardPart) Match(ctx *routeMatchContext, token string) bool {
 	token = token[1:]
-	if part.param != "" {
+	if ctx != nil && part.param != "" {
 		setParam(ctx, part.param, token)
 	}
 	return true
@@ -68,6 +71,10 @@ func (part *wildcardPart) Eq(other Part) bool {
 		return otherWp.param == part.param
 	}
 	return false
+}
+
+func (part *wildcardPart) Expr() string {
+	return "*"
 }
 
 func (part *wildcardPart) ParameterName() string {
@@ -102,7 +109,7 @@ func (part *regexPart) Match(ctx *routeMatchContext, token string) bool {
 		return false
 	}
 	// If a parameter is set, act as a wildcard param.
-	if part.param != "" {
+	if ctx != nil && part.param != "" {
 		// If a token matched, store the matched value as a route Param
 		setParam(ctx, part.param, token)
 	}
@@ -114,6 +121,10 @@ func (part *regexPart) Eq(other Part) bool {
 		return otherRp.expr.String() == part.expr.String() && otherRp.param == part.param
 	}
 	return false
+}
+
+func (part *regexPart) Expr() string {
+	return part.expr.String()
 }
 
 func (part *regexPart) ParameterName() string {
@@ -129,7 +140,6 @@ func (part *regexPart) SetParameterName(s string) {
 // defaultRoute is the default behavior for router, which is to match requests exactly.
 type defaultRoute struct {
 	origExpr string
-	mws      []middleware.Middleware
 	method   string
 	parts    []Part
 	ctx      *routeMatchContext
@@ -141,7 +151,6 @@ type defaultRoute struct {
 func build_defaultRoute(method, expr string) (*defaultRoute, error) {
 	route := &defaultRoute{
 		origExpr: expr,
-		mws:      make([]middleware.Middleware, 0),
 		method:   method,
 		parts:    make([]Part, 0),
 		ctx:      newRMC(),
@@ -182,11 +191,21 @@ func (route *defaultRoute) Length() int {
 	return len(route.parts)
 }
 
-// Attach middleware to the route. Middleware is handled in attachment order.
+// Get a part from the route.
 //
 // See interface Route.
-func (route *defaultRoute) Attach(mw middleware.Middleware) {
-	route.mws = append(route.mws, mw)
+func (route *defaultRoute) Part(idx int) Part {
+	if idx >= route.Length() {
+		return nil
+	}
+	return route.parts[idx]
+}
+
+// Return the route method.
+//
+// See interface Route.
+func (route *defaultRoute) Method() string {
+	return route.method
 }
 
 // Match a request and update its context.
@@ -201,12 +220,6 @@ func (route *defaultRoute) MatchAndUpdateContext(req *http.Request) *http.Reques
 	expr := req.URL.Path
 	if strings.Count(expr, "/") != len(route.parts) {
 		return nil
-	}
-	// Run any attached middleware
-	for _, mw := range route.mws {
-		if req = mw(req); req == nil {
-			return nil
-		}
 	}
 
 	var token string

--- a/pkg/route/default.go
+++ b/pkg/route/default.go
@@ -33,6 +33,13 @@ func (part *stringPart) Match(ctx *routeMatchContext, token string) bool {
 	}
 }
 
+func (part *stringPart) Eq(other Part) bool {
+	if otherSp, ok := other.(*stringPart); ok {
+		return otherSp.val == part.val
+	}
+	return false
+}
+
 // WILDCARDS
 
 // Wildcard route Parts store parameters for use by the router in handlers.
@@ -54,6 +61,13 @@ func (part *wildcardPart) Match(ctx *routeMatchContext, token string) bool {
 		setParam(ctx, part.param, token)
 	}
 	return true
+}
+
+func (part *wildcardPart) Eq(other Part) bool {
+	if otherWp, ok := other.(*wildcardPart); ok {
+		return otherWp.param == part.param
+	}
+	return false
 }
 
 func (part *wildcardPart) ParameterName() string {
@@ -93,6 +107,13 @@ func (part *regexPart) Match(ctx *routeMatchContext, token string) bool {
 		setParam(ctx, part.param, token)
 	}
 	return true
+}
+
+func (part *regexPart) Eq(other Part) bool {
+	if otherRp, ok := other.(*regexPart); ok {
+		return otherRp.expr.String() == part.expr.String() && otherRp.param == part.param
+	}
+	return false
 }
 
 func (part *regexPart) ParameterName() string {

--- a/pkg/route/default.go
+++ b/pkg/route/default.go
@@ -109,6 +109,7 @@ func (part *regexPart) SetParameterName(s string) {
 type defaultRoute struct {
 	origExpr string
 	mws      []middleware.Middleware
+	method   string
 	parts    []Part
 	ctx      *routeMatchContext
 }
@@ -116,10 +117,11 @@ type defaultRoute struct {
 // Tokenize and parse a route expression into a defaultRoute.
 //
 // See interface Route.
-func build_defaultRoute(expr string) (*defaultRoute, error) {
+func build_defaultRoute(method, expr string) (*defaultRoute, error) {
 	route := &defaultRoute{
 		origExpr: expr,
 		mws:      make([]middleware.Middleware, 0),
+		method:   method,
 		parts:    make([]Part, 0),
 		ctx:      newRMC(),
 	}
@@ -170,6 +172,9 @@ func (route *defaultRoute) Attach(mw middleware.Middleware) {
 //
 // See interface Route.
 func (route *defaultRoute) MatchAndUpdateContext(req *http.Request) *http.Request {
+	if req.Method != route.method {
+		return nil
+	}
 	route.ctx.ResetOnto(req.Context())
 	// Check for path length
 	expr := req.URL.Path

--- a/pkg/route/default.go
+++ b/pkg/route/default.go
@@ -124,7 +124,7 @@ func (part *regexPart) Eq(other Part) bool {
 }
 
 func (part *regexPart) Expr() string {
-	return part.expr.String()
+	return "*"
 }
 
 func (part *regexPart) ParameterName() string {

--- a/pkg/route/part.go
+++ b/pkg/route/part.go
@@ -31,6 +31,8 @@ type Part interface {
 	// Compare to another part.
 	// Should return equal iff the result of Match would be the exact same, given the same context and token.
 	Eq(other Part) bool
+	// Get an expression for the part.
+	Expr() string
 }
 
 // paramParts may or may not store some parameter.

--- a/pkg/route/part.go
+++ b/pkg/route/part.go
@@ -28,6 +28,9 @@ type Part interface {
 	// If it does, it should return the request, with any modifications done on
 	// behalf of the Part (usually wildcard tokens)
 	Match(ctx *routeMatchContext, token string) bool
+	// Compare to another part.
+	// Should return equal iff the result of Match would be the exact same, given the same context and token.
+	Eq(other Part) bool
 }
 
 // paramParts may or may not store some parameter.

--- a/pkg/route/partial.go
+++ b/pkg/route/partial.go
@@ -66,7 +66,7 @@ func (part *partialEndPart) Eq(other Part) bool {
 }
 
 func (part *partialEndPart) Expr() string {
-	return part.subPart.Expr() + "+"
+	return "*"
 }
 
 func (part *partialEndPart) ParameterName() string {

--- a/pkg/route/partial.go
+++ b/pkg/route/partial.go
@@ -57,6 +57,16 @@ func (part *partialEndPart) Match(ctx *routeMatchContext, token string) bool {
 	return true
 }
 
+func (part *partialEndPart) Eq(other Part) bool {
+	if otherPep, ok := other.(*partialEndPart); ok {
+		if otherPep.param != part.param {
+			return false
+		}
+		return part.subPart.Eq(otherPep.subPart)
+	}
+	return false
+}
+
 func (part *partialEndPart) ParameterName() string {
 	return part.param
 }

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -2,8 +2,6 @@ package route
 
 import (
 	"net/http"
-
-	"github.com/cloudretic/router/pkg/middleware"
 )
 
 type Route interface {
@@ -15,10 +13,15 @@ type Route interface {
 	//
 	// Route implementations may determine how to represent their own length.
 	Length() int
-	// Attach middleware to the route.
+	// Get the part at idx.
+	// Returns nil if there is no part.
 	//
-	// Route implementations may define the order that middleware is handled.
-	Attach(middleware.Middleware)
+	// Route implementations must implement this definition exactly.
+	Part(idx int) Part
+	// Get the method of the route.
+	//
+	// Route implementations must return a nonempty string containing exactly one method, compliant with http.MethodX
+	Method() string
 	// Match a request and update its context.
 	//
 	// Route implementations must return nil if a request does not match the Route, but may otherwise define any return behavior.

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -26,14 +26,14 @@ type Route interface {
 }
 
 // Create a new Route based on a string expression.
-func New(expr string, confs ...ConfigFunc) (Route, error) {
+func New(method, expr string, confs ...ConfigFunc) (Route, error) {
 	// Determine route type
 	var r Route
 	var err error
 	if isPartialRouteExpr(expr) {
-		r, err = build_partialRoute(expr)
+		r, err = build_partialRoute(method, expr)
 	} else {
-		r, err = build_defaultRoute(expr)
+		r, err = build_defaultRoute(method, expr)
 	}
 	if err != nil {
 		return nil, err
@@ -49,8 +49,8 @@ func New(expr string, confs ...ConfigFunc) (Route, error) {
 
 // Create a new Route based on a string expression, and panic if this fails.
 // You should not use this unless you are creating a route on program start and do not intend to modify the route after the fact.
-func Declare(expr string, confs ...ConfigFunc) Route {
-	r, err := New(expr, confs...)
+func Declare(method, expr string, confs ...ConfigFunc) Route {
+	r, err := New(method, expr, confs...)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/route/route_test.go
+++ b/pkg/route/route_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestStringRoute(t *testing.T) {
-	rt, err := New("/test")
+	rt, err := New(http.MethodGet, "/test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -22,7 +22,7 @@ func TestStringRoute(t *testing.T) {
 }
 
 func TestWildcardRoute(t *testing.T) {
-	rt, err := New("/[param1]/[param2]/[param3]")
+	rt, err := New(http.MethodGet, "/[param1]/[param2]/[param3]")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +42,7 @@ func TestWildcardRoute(t *testing.T) {
 }
 
 func TestRegexRoute(t *testing.T) {
-	rt, err := New("/{[a-zA-Z]{4}}")
+	rt, err := New(http.MethodGet, "/{[a-zA-Z]{4}}")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func TestRegexRoute(t *testing.T) {
 
 func TestPartialRoute(t *testing.T) {
 	t.Run("basics", func(t *testing.T) {
-		rt, err := New(`/partial/+`)
+		rt, err := New(http.MethodGet, `/partial/+`)
 		if reflect.TypeOf(rt) != reflect.TypeOf(&partialRoute{}) {
 			t.Fatalf("/partial/+ should create a partialRoute, got %s", reflect.TypeOf(rt).String())
 		}
@@ -75,7 +75,7 @@ func TestPartialRoute(t *testing.T) {
 		}
 	})
 	t.Run("filename", func(t *testing.T) {
-		rt, err := New(`/file/[filename]{\w+(?:\.\w+)?}+`)
+		rt, err := New(http.MethodGet, `/file/[filename]{\w+(?:\.\w+)?}+`)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -109,7 +109,7 @@ func TestPartialRoute(t *testing.T) {
 }
 
 func TestMethodRoute(t *testing.T) {
-	rt, err := New("/test", WithMethods(http.MethodPost))
+	rt, err := New(http.MethodPost, "/test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/router/bench_router_test.go
+++ b/pkg/router/bench_router_test.go
@@ -37,11 +37,11 @@ func declareReq(path string) *http.Request {
 // 1519 ns/op, 1387 B/op, 12 allocs/op
 func BenchmarkBasicRouter(b *testing.B) {
 	rt := Declare(
-		WithRoute(route.Declare("/", route.WithMethods(http.MethodGet)), okHandler("root")),
-		WithRoute(route.Declare("/[wildcard]", route.WithMethods(http.MethodGet)), rpHandler("wildcard")),
-		WithRoute(route.Declare(`/route/{[a-zA-Z]+}`, route.WithMethods(http.MethodGet)), okHandler("letters")),
-		WithRoute(route.Declare(`/route/[id]{[\w]{4}}`, route.WithMethods(http.MethodGet)), rpHandler("id")),
-		WithRoute(route.Declare(`/static/file/[filename]{\w+(?:\.\w+)?}+`, route.WithMethods(http.MethodGet)), rpHandler("filename")),
+		WithRoute(route.Declare(http.MethodGet, "/"), okHandler("root")),
+		WithRoute(route.Declare(http.MethodGet, "/[wildcard]"), rpHandler("wildcard")),
+		WithRoute(route.Declare(http.MethodGet, `/route/{[a-zA-Z]+}`), okHandler("letters")),
+		WithRoute(route.Declare(http.MethodGet, `/route/[id]{[\w]{4}}`), rpHandler("id")),
+		WithRoute(route.Declare(http.MethodGet, `/static/file/[filename]{\w+(?:\.\w+)?}+`), rpHandler("filename")),
 	)
 	benchReqs := []*http.Request{
 		declareReq("/"),

--- a/pkg/router/bench_router_test.go
+++ b/pkg/router/bench_router_test.go
@@ -34,7 +34,7 @@ func declareReq(path string) *http.Request {
 // Basic router benchmark.
 // For more involved benchmarks, see /bench. This serves as a baseline value, not a robust example under load.
 //
-// 1519 ns/op, 1387 B/op, 12 allocs/op
+// 1,258 ns/op, 1,387 B/op, 12 allocs/op
 func BenchmarkBasicRouter(b *testing.B) {
 	rt := Declare(
 		WithRoute(route.Declare(http.MethodGet, "/"), okHandler("root")),

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -85,7 +85,7 @@ func runEvalRequest(t *testing.T,
 // Doesn't check to see if those options work, just that they compile and don't cause errors. Check options individually.
 func TestNewRouter(t *testing.T) {
 	_, err := New(
-		WithRoute(route.Declare("/"), okHandler("root")),
+		WithRoute(route.Declare(http.MethodGet, "/"), okHandler("root")),
 		WithNotFound(nfHandler()),
 	)
 	if err != nil {
@@ -95,11 +95,11 @@ func TestNewRouter(t *testing.T) {
 
 func TestBasicRoutes(t *testing.T) {
 	r, err := New(
-		WithRoute(route.Declare("/"), okHandler("root")),
-		WithRoute(route.Declare("/[wildcard]"), rpHandler("wildcard")),
-		WithRoute(route.Declare(`/route/{[a-zA-Z]+}`), okHandler("letters")),
-		WithRoute(route.Declare(`/route/[id]{[\w]{4}}`), rpHandler("id")),
-		WithRoute(route.Declare(`/static/file/[filename]{\w+(?:\.\w+)?}+`), rpHandler("filename")),
+		WithRoute(route.Declare(http.MethodGet, "/"), okHandler("root")),
+		WithRoute(route.Declare(http.MethodGet, "/[wildcard]"), rpHandler("wildcard")),
+		WithRoute(route.Declare(http.MethodGet, `/route/{[a-zA-Z]+}`), okHandler("letters")),
+		WithRoute(route.Declare(http.MethodGet, `/route/[id]{[\w]{4}}`), rpHandler("id")),
+		WithRoute(route.Declare(http.MethodGet, `/static/file/[filename]{\w+(?:\.\w+)?}+`), rpHandler("filename")),
 	)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
- Route now includes methods as an inherent part of them rather than as middleware
- Routers now group routes by their "prefix", or first part, if that part is a static string. Massive improvement on large APIs (see GitHub benchmark). Currently wildcard/regex/partial not supported; if any route starts with these they get lumped into the same group.