### PR TITLE
Documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Router
 
-> ***The current development branch is `v1.1`.***
+> ***The current development branch is `v1.2`.***
 
 We welcome community contributions to `matcha`!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,12 @@
 
 > ***The current development branch is `v1.1`.***
 
-We welcome community contributions to `router`!
+We welcome community contributions to `matcha`!
 
 ## Getting Started
 
-1. Ensure you have [installed Golang](https://go.dev/dl/) on your development machine. `router` is currently on version `1.20.2`.
-2. Create a fork of `router` to your personal GitHub account. Direct branches or pushes to the `CloudRETIC` repository are not accepted.
+1. Ensure you have [installed Golang](https://go.dev/dl/) on your development machine. `matcha` is currently on version `1.20.2`.
+2. Create a fork of `matcha` to your personal GitHub account. Direct branches or pushes to the `CloudRETIC` repository are not accepted.
 3. Clone your personal fork to your development machine, and enter the directory.
 4. Add the upstream repository: `git remote add upstream [http-or-ssh-address]`
 
@@ -34,9 +34,9 @@ Once your changes are approved, they'll be squash-and-merged into the feature br
 
 ## Guidelines
 
-Currently, new submissions to `router` are subject to the following criteria:
+Currently, new submissions to `matcha` are subject to the following criteria:
 
-1. **Performance**: Changes must not significantly decrease performance. Benchmarks for routers and routes, as well as a more comprehensive benchmark on the GitHub API (courtesy of [julienschmidt](https://github.com/julienschmidt/go-http-routing-benchmark)) are provided to help evaluate this as you work. Run benchmarks before and after making changes to most accurately assess impact.
+1. **Performance**: Changes must not significantly decrease performance unless they are urgent bugfixes. Benchmarks for routers and routes, as well as a more comprehensive benchmark on the GitHub API (courtesy of [julienschmidt](https://github.com/julienschmidt/go-http-routing-benchmark)) are provided to help evaluate this as you work. Run benchmarks before and after making changes to most accurately assess impact.
 2. **Testing**: Test coverage should stay above 95%. New behavior is expected to have associated unit tests
 3. **Documentation**: CloudRETIC strongly encourages detailed documentation of code, and pull requests will be evaluated on quality of comments and external documentation in `/docs`.
 4. **Style**: While style is massively subjective, you should follow good Go code practices. We use [this list](https://github.com/golang/go/wiki/CodeReviewComments#gofmt) to evaluate style.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,39 @@
-# cloudretic/router
+# matcha
 
 [![Coverage Status](https://coveralls.io/repos/github/cloudretic/router/badge.svg)](https://coveralls.io/github/cloudretic/router)
 
-`cloudretic/router` is an actively developed HTTP router for Go, primarily developed for CloudRETIC's API handlers but free to use by anyone under the Apache 2.0 license.
-
-> **In version 1.1, `cloudretic/router` will be renamed to `cloudretic/matcha`.** The former name is too generic to support long-term. We apologize for any inconvenience caused by this change.
+`cloudretic/matcha` is an actively developed HTTP router for Go, primarily developed for CloudRETIC's API handlers but free to use by anyone under the Apache 2.0 license.
 
 ## Features
 
 - Static string routes, wildcard parameters, regex validation, and prefix routes
 - Highly customizable route/router construction; use the syntax that feels best to you
 - Comprehensive and passing test coverage, and extensive benchmarks to track performance
-
-### Upcoming in v1.1
-
-- More native middleware
+- Native middleware
   - Log inbound requests
   - Require query parameters
   - Attach middleware to routes to target specific endpoints
 - CORS handling
   - Native middleware to write CORS headers on responses
   - A premade handler to manage OPTIONS requests
-- Significant performance improvements
-  - GitHub API benchmark performs 2.5x faster than v1.0
+
+## Benchmarks
+
+These benchmarks are run on the GitHub API provided by [julienschmidt](https://github.com/julienschmidt/go-http-routing-benchmark), updated to match the current Go version.
+
+Go benchmarks provide a measurement of `ns/op` and `B/op`, representing how much time and memory was used for one "operation", which in this case is one full loop of handling *every route* in the API. Since speed in nanoseconds can be machine-dependent, we have provided a relative value instead, where the value is (`matcha` result)/(`other` result). Higher is better/faster.
+
+Router Name | Relative Speed | Memory Use
+--- | --- | ---
+[`gorilla/mux`](https://github.com/gorilla/mux) | .06x | 199,686 B/op
+`matcha` | 1.0x | 139,064 B/op
+[`chi`](https://github.com/go-chi/chi) | 1.52x | 61,713 B/op
+[`httprouter`](https://github.com/julienschmidt/httprouter) | 5.87x | 13,792
+[`gin`](https://github.com/gin-gonic/gin) | 5.87x | 0 B/op
 
 ## Installation
 
-`go get github.com/cloudretic/router[@version]`
+`go get github.com/cloudretic/matcha[@version]`
 
 Supported versions:
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Router Name | Relative Speed | Memory Use
 
 Supported versions:
 
-- `main (v1.0)`
-- `v1.1`
+- `v1.0`
+- `main (v1.1)`
+- `v1.2`
 
 ## Basic Usage
 

--- a/docs/CORS.md
+++ b/docs/CORS.md
@@ -1,6 +1,6 @@
 # Cross-Origin Resource Sharing (CORS)
 
-When requesting resources from a remote server, browsers typically require the server to describe the conditions under which a request may access those resources. This is called Cross-Origin Resource Sharing. `router` has some tools built in to help you handle CORS requests, if it's required for your application.
+When requesting resources from a remote server, browsers typically require the server to describe the conditions under which a request may access those resources. This is called Cross-Origin Resource Sharing. `matcha` has some tools built in to help you handle CORS requests, if it's required for your application.
 
 ## How CORS Works
 
@@ -18,7 +18,7 @@ If the request is simple, it's sent as normal. If it is not simple, the browser 
 - `Access-Control-Max-Age`: Indicates how long a resource may be cached in seconds.
 - `Access-Control-Allow-Credentials`: Indicates if a request may use credentials (cookies, authorization, or TLS).
 
-All of these can be empty, a list, or `*`, which indicates that any value is allowed/exposed. `router` represents these with the `*AccessControlOptions` struct, used to define how a Router should treat CORS requests.
+All of these can be empty, a list, or `*`, which indicates that any value is allowed/exposed. `matcha` represents these with the `*AccessControlOptions` struct, used to define how a Router should treat CORS requests.
 
 ## Setting Up CORS
 
@@ -26,7 +26,7 @@ There are three ways to set CORS headers on responses.
 
 - `Router` can set the default headers for all routes using the `DefaultCORSHeaders` configuration function.
 - `Route` can set the headers for itself only using the `CORSHeaders` configuration function.
-- `PreflightCORS` can be used to define an OPTIONS route that returns the given access control headers. *`router` does not currently automatically generate these routes.*
+- `PreflightCORS` can be used to define an OPTIONS route that returns the given access control headers. *`matcha` does not currently automatically generate these routes.*
 
 To manually manipulate CORS headers, `package cors` provides `SetCORSResponseHeaders` that will set the headers based on an `*AccessControlOptions` object. This can be used in the event that the above options don't fit your use case. We'd encourage you to submit an issue on GitHub if your use case isn't immediately supported.
 

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -1,6 +1,6 @@
 # Adapting Router
 
-`router` includes the `Adapter` interface to help define functionality that receives HTTP requests through methods other than direct HTTP/S, such as with serverless computing or through a message queue. External adapters aren't required to use this, but it may help.
+`matcha` includes the `Adapter` interface to help define functionality that receives HTTP requests through methods other than direct HTTP/S, such as with serverless computing or through a message queue. External adapters aren't required to use this, but it may help.
 
 ## Implementing the Adapter Interface
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -13,12 +13,12 @@ Generally, it is encouraged that you pick one and stick to it for both routes an
 
 ## Handlers
 
-Some routers use specialized handler functions or types in their APIs. While separating from Go's standard HTTP library can lead to performance improvements, it also leads to stronger coupling with the package being used. We've re-implemented some of the interface members of the HTTP library, allowing for high performance without the need for refactoring code to migrate to `router`. Any handler that works with Go's standard library works for `router` as well.
+Some routers use specialized handler functions or types in their APIs. While separating from Go's standard HTTP library can lead to performance improvements, it also leads to stronger coupling with the package being used. We've re-implemented some of the interface members of the HTTP library, allowing for high performance without the need for refactoring code to migrate to `matcha`. Any handler that works with Go's standard library works for `matcha` as well.
 
 ## Middleware
 
-`router` has a different middleware definition than most open-source routers, opting for `func(http.ResponseWriter, *http.Request) *Request` as opposed to `http.Handler`. This is a deliberate style choice to permit middleware to explicitly reject requests and return control to the caller. Middleware chains are constructed by `Attach`ing each middleware in series.
+`matcha` has a different middleware definition than most open-source routers, opting for `func(http.ResponseWriter, *http.Request) *Request` as opposed to `http.Handler`. This is a deliberate style choice to permit middleware to explicitly reject requests and return control to the caller. Middleware chains are constructed by `Attach`ing each middleware in series.
 
 ## Explicit Route Creation
 
-Where most routers add routes via a direct call to the constructed router, `router` requires the explicit construction of a route via `route.New` prior to being added. Creation of a route may fail, and the explicit creation is a necessity to communicate that behavior and; addition of a route may not
+Where most routers add routes via a direct call to the constructed router, `matcha` requires the explicit construction of a route via `route.New` prior to being added. Creation of a route may fail, and the explicit creation is a necessity to communicate that behavior and; addition of a route may not

--- a/docs/design.md
+++ b/docs/design.md
@@ -14,11 +14,3 @@ Generally, it is encouraged that you pick one and stick to it for both routes an
 ## Handlers
 
 Some routers use specialized handler functions or types in their APIs. While separating from Go's standard HTTP library can lead to performance improvements, it also leads to stronger coupling with the package being used. We've re-implemented some of the interface members of the HTTP library, allowing for high performance without the need for refactoring code to migrate to `matcha`. Any handler that works with Go's standard library works for `matcha` as well.
-
-## Middleware
-
-`matcha` has a different middleware definition than most open-source routers, opting for `func(http.ResponseWriter, *http.Request) *Request` as opposed to `http.Handler`. This is a deliberate style choice to permit middleware to explicitly reject requests and return control to the caller. Middleware chains are constructed by `Attach`ing each middleware in series.
-
-## Explicit Route Creation
-
-Where most routers add routes via a direct call to the constructed router, `matcha` requires the explicit construction of a route via `route.New` prior to being added. Creation of a route may fail, and the explicit creation is a necessity to communicate that behavior and; addition of a route may not

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-What's next for `router`?
+What's next for `matcha`?
 
 ## Version 1.1: Compatibility
 

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -8,7 +8,7 @@ Routes are defined using *expressions* and made up of *parts*. When creating a r
 
 ## Route Parts
 
- `router` has support for special syntax to customize the behavior of "parts". Currently, it supports:
+ `matcha` has support for special syntax to customize the behavior of "parts". Currently, it supports:
 
 - Static strings
 - Wildcard parameters


### PR DESCRIPTION
Primarily represents the name change from `router` to `matcha`, but there's also additional information regarding benchmarks in the README.